### PR TITLE
added stamp changes

### DIFF
--- a/maps/torch/items/stamps.dm
+++ b/maps/torch/items/stamps.dm
@@ -19,7 +19,7 @@
 	icon_state = "stamp-brig"
 
 /obj/item/stamp/solgov
-	name = "\improper Sol Central Government rubber stamp"
+	name = "\improper United Galactic Nations rubber stamp"
 	icon_state = "stamp-solgov"
 
 /obj/item/stamp/nt
@@ -37,3 +37,18 @@
 /obj/item/stamp/path
 	name = "pathfinder's rubber stamp"
 	icon_state = "stamp-pf"
+
+/obj/item/stamp/rep
+
+	name = "UGN Representative's Rubber Stamp"
+	icon_state = "stamp-solgov"
+
+/obj/item/stamp/rep/approved
+
+	name = "UGN Representative's Approved Rubber Stamp"
+	icon_state = "stamp-solgov"
+
+/obj/item/stamp/rep/denied
+
+	name = "UGN Representative's Denied Rubber Stamp"
+	icon_state = "stamp-solgov"

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -65,9 +65,9 @@
 		/obj/item/clothing/suit/storage/toggle/suit/black,
 		/obj/item/clothing/glasses/sunglasses/big,
 		/obj/item/storage/belt/general,
-		/obj/item/stamp/rep
-		/obj/item/stamp/rep/approved
-		/obj/item/stamp/rep/denied
+		/obj/item/stamp/rep,
+		/obj/item/stamp/rep/approved,
+		/obj/item/stamp/rep/denied,
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel, /obj/item/storage/backpack/messenger)),
 	)
 

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -47,7 +47,7 @@
 	)
 
 /obj/structure/closet/secure_closet/representative
-	name = "\improper Sol Central Government representative's locker"
+	name = "\improper United Galactic Nations representative's locker"
 	req_access = list(access_representative)
 	closet_appearance = /singleton/closet_appearance/secure_closet/torch/sol/rep
 

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -65,6 +65,9 @@
 		/obj/item/clothing/suit/storage/toggle/suit/black,
 		/obj/item/clothing/glasses/sunglasses/big,
 		/obj/item/storage/belt/general,
+		/obj/item/stamp/rep
+		/obj/item/stamp/rep/approved
+		/obj/item/stamp/rep/denied
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack, /obj/item/storage/backpack/satchel, /obj/item/storage/backpack/messenger)),
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just added rubber stamps for the UGN Rep.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
pretty necessary for RP
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof of Testing
check workflows.
<!-- Can be screenshots, detailed information about functioning, etc. Just give some indication that it won't break when we testmerge. -->

## Changelog
added rubber stamps to UGN rep locker with approved, denied, and generic
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: rubber stamps for UGN rep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
