### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/donotmerge-blocker.yml
+++ b/.github/workflows/donotmerge-blocker.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [synchronize, opened, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   donotmerge-blocker:
     name: Enforce Do Not Merge Labels


### PR DESCRIPTION
Potential fix for [https://github.com/Unionstation-13/Unionstation13/security/code-scanning/1](https://github.com/Unionstation-13/Unionstation13/security/code-scanning/1)

To address this issue, we should add an explicit `permissions` block to the workflow to restrict the permissions granted to the GITHUB_TOKEN during workflow runs. Since this workflow only reads pull request metadata and does not perform any write operations, the most restrictive and appropriate permission setting is `contents: read`. This can be applied globally at the top level of the workflow (recommended if all jobs need the same permissions). The edit should insert the following above the `jobs:` section and after the `name` and `on` sections:

```yaml
permissions:
  contents: read
```

Alternatively, if more granularity is needed for future expansion, you could set this block for each job, but in this specific snippet, a workflow-level setting is most efficient. No further changes or imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
