### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -100,8 +100,15 @@ function linkify(parent, insertBefore, text) {
 		parent.insertBefore(document.createTextNode(text.substring(start, match.index)), insertBefore);
 
 		var href = match[0];
-		if (!/^https?:\/\//i.test(match[0])) {
+		if (/^https?:\/\//i.test(match[0])) {
+			// Safe, do not modify
+		} else if (/^www\./i.test(match[0])) {
 			href = "http://" + match[0];
+		} else {
+			// Unsafe protocol, insert plain text instead of a link
+			parent.insertBefore(document.createTextNode(match[0]), insertBefore);
+			start = regex.lastIndex;
+			continue;
 		}
 
 		// add the link


### PR DESCRIPTION
Potential fix for [https://github.com/Unionstation-13/Unionstation13/security/code-scanning/4](https://github.com/Unionstation-13/Unionstation13/security/code-scanning/4)

To prevent the DOM text from being reinterpreted as dangerous HTML and introducing a cross-site scripting vulnerability, ensure that only safe URLs (protocols) are assigned to the `href` attribute of `<a>` elements. The best way is to whitelist allowed protocols (`http`, `https`), and default to something safe if the match does not yield a valid URL.

**How to fix:**  
- Validate the protocol of the matched URL before assigning it to `href`.  
- Only allow URLs starting with `http://` or `https://`. For those starting with `www.`, prepend `http://`.  
- For all other matches, do not create a link (insert plain text instead) or fallback to a safe value.

**Where to change:**  
- In the `linkify` function (lines 94-120), specifically where `href` is assigned and used for `link.href` (lines 102-109).

**What is needed:**  
- Protocol check: A helper function, or inline validation, to ensure the URL is safe before assignment.  
- No external imports are required, as this can be done with string checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
