### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/nano/js/libraries/jquery-ui.js
+++ b/nano/js/libraries/jquery-ui.js
@@ -1175,7 +1175,9 @@ $.fn.position = function( options ) {
 	options = $.extend( {}, options );
 
 	var atOffset, targetWidth, targetHeight, targetOffset, basePosition, dimensions,
-		target = $( options.of ),
+		target = (typeof options.of === "string")
+			? $(document).find(options.of)
+			: $(options.of),
 		within = $.position.getWithinInfo( options.within ),
 		scrollInfo = $.position.getScrollInfo( within ),
 		collision = ( options.collision || "flip" ).split( " " ),

--- a/nano/js/libraries/jquery-ui.js
+++ b/nano/js/libraries/jquery-ui.js
@@ -1175,6 +1175,8 @@ $.fn.position = function( options ) {
 	options = $.extend( {}, options );
 
 	var atOffset, targetWidth, targetHeight, targetOffset, basePosition, dimensions,
+		// Important: If options.of is a string, use .find for safe CSS selector resolution,
+		// never interpret it as HTML. This avoids XSS vulnerabilities if untrusted input passed.
 		target = (typeof options.of === "string")
 			? $(document).find(options.of)
 			: $(options.of),


### PR DESCRIPTION
Potential fix for [https://github.com/Unionstation-13/Unionstation13/security/code-scanning/5](https://github.com/Unionstation-13/Unionstation13/security/code-scanning/5)

To fix this issue, `$.fn.position` should constrain its use of `options.of` such that it is not evaluated as HTML if `options.of` is a string. The safest approach is:
- If `options.of` is a string, use it only as a CSS selector by using `jQuery.find`, which does not interpret strings as HTML.
- If `options.of` is a DOM element, jQuery object, window, or event, handle as before.
Thus, replace `target = $(options.of)` with a conditional:
- If `options.of` is a string, use `target = $(document).find(options.of)` or similar (using the current document as context).
- Otherwise, use `target = $(options.of)`.

This change should be made in nano/js/libraries/jquery-ui.js at the relevant line in `$.fn.position`.

No new imports are needed. The modification is just an update to this one code path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
