### PR TITLE
Potential fix for code scanning alert no. 8: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/nano/js/libraries/jquery.js
+++ b/nano/js/libraries/jquery.js
@@ -5597,8 +5597,8 @@ jQuery.extend({
 					tag = (rtagName.exec( elem ) || [ "", "" ])[ 1 ].toLowerCase();
 					wrap = wrapMap[ tag ] || wrapMap._default;
 
-					// Avoid unsafe expansion of self-closing tags if elem contains quotes or angle brackets in attribute values.
-					if (/["'<]/.test(elem)) {
+					// Avoid unsafe expansion of self-closing tags if elem contains quotes, angle brackets, or slashes in attribute values.
+					if (/["'<>\//]/.test(elem)) {
 						// Insert elem as is to avoid breaking attributes—browser will handle tag expansion if needed.
 						tmp.innerHTML = wrap[1] + elem + wrap[2];
 					} else {

--- a/nano/js/libraries/jquery.js
+++ b/nano/js/libraries/jquery.js
@@ -5597,7 +5597,13 @@ jQuery.extend({
 					tag = (rtagName.exec( elem ) || [ "", "" ])[ 1 ].toLowerCase();
 					wrap = wrapMap[ tag ] || wrapMap._default;
 
-					tmp.innerHTML = wrap[1] + elem.replace( rxhtmlTag, "<$1></$2>" ) + wrap[2];
+					// Avoid unsafe expansion of self-closing tags if elem contains quotes or angle brackets in attribute values.
+					if (/["'<]/.test(elem)) {
+						// Insert elem as is to avoid breaking attributes—browser will handle tag expansion if needed.
+						tmp.innerHTML = wrap[1] + elem + wrap[2];
+					} else {
+						tmp.innerHTML = wrap[1] + elem.replace( rxhtmlTag, "<$1></$2>" ) + wrap[2];
+					}
 
 					// Descend through wrappers to the right content
 					j = wrap[0];


### PR DESCRIPTION
Potential fix for [https://github.com/Unionstation-13/Unionstation13/security/code-scanning/8](https://github.com/Unionstation-13/Unionstation13/security/code-scanning/8)

The problem can be fixed by ensuring the expansion of self-closing tags only occurs on HTML text outside attribute values. Since reliable HTML parsing is tricky with regex, the best mitigation in this legacy context is to expand only *trusted* or controlled markup, or to use a DOM-based approach instead of a regex for expansion. Since we cannot introduce a new HTML parser, the most robust patch (without significantly altering jQuery's API or using third-party dependencies) is to avoid expanding self-closing tags via regex at all, or to only expand the very specific tags known to require this, restricting scope.

**Best fix:**  
Replace the problematic `elem.replace( rxhtmlTag, "<$1></$2>" )` on line 5600 with a safer transformation. The recommended in-place fix is:

- Use a DOM element to set `innerHTML` to the fragment,
- Then extract the HTML, which lets the browser do the tag expansion safely,
- Or, as a mitigation, only apply the regex when `elem` does **not** contain attribute characters (like quotes), which is a strict but safe workaround.

**Edits to make:**
- Change line 5600 to avoid using the unsafe regex replacement for all cases. Instead, only do the regex replacement if there are no suspicious characters, or—if possible—avoid this replacement entirely.

**Needed:**  
Just modify line 5600; no imports or new methods needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
