### PR TITLE
Potential fix for code scanning alert no. 6: Implicit narrowing conversion in compound assignment

### DIFF
--- a/tools/dmitool/src/main/java/dmitool/DMI.java
+++ b/tools/dmitool/src/main/java/dmitool/DMI.java
@@ -27,7 +27,7 @@ import java.util.List;
 public class DMI implements Comparator<IconState> {
     int w, h;
     List<IconState> images;
-    int totalImages = 0;
+    long totalImages = 0;
     RGBA[] palette;
     boolean isPaletted;
     


### PR DESCRIPTION
Potential fix for [https://github.com/Unionstation-13/Unionstation13/security/code-scanning/6](https://github.com/Unionstation-13/Unionstation13/security/code-scanning/6)

To fix this issue, the destination variable `totalImages` should be at least as wide as the source, so both should use the `long` type. Therefore, the type declaration for `totalImages` on line 30 of `DMI.java` should be changed from `int` to `long`. This change will ensure that accumulated values are never lost due to narrowing conversion. No further changes are needed since the variable is only incremented and compared in places we've seen. The only line to change is the `int totalImages = 0;` definition to `long totalImages = 0;`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
