### PR TITLE
Potential fix for code scanning alert no. 11: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/nano/js/libraries/jquery.js
+++ b/nano/js/libraries/jquery.js
@@ -5597,13 +5597,9 @@ jQuery.extend({
 					tag = (rtagName.exec( elem ) || [ "", "" ])[ 1 ].toLowerCase();
 					wrap = wrapMap[ tag ] || wrapMap._default;
 
-					// Avoid unsafe expansion of self-closing tags if elem contains quotes, angle brackets, or slashes in attribute values.
-					if (/["'<>\//]/.test(elem)) {
-						// Insert elem as is to avoid breaking attributes—browser will handle tag expansion if needed.
-						tmp.innerHTML = wrap[1] + elem + wrap[2];
-					} else {
-						tmp.innerHTML = wrap[1] + elem.replace( rxhtmlTag, "<$1></$2>" ) + wrap[2];
-					}
+					// Avoid unsafe expansion of self-closing tags to prevent invalidating sanitization and possible XSS attacks.
+					// Always insert elem as is—browser will handle tag expansion if needed.
+					tmp.innerHTML = wrap[1] + elem + wrap[2];
 
 					// Descend through wrappers to the right content
 					j = wrap[0];


### PR DESCRIPTION
Potential fix for [https://github.com/Unionstation-13/Unionstation13/security/code-scanning/11](https://github.com/Unionstation-13/Unionstation13/security/code-scanning/11)

**General Fix:**  
Avoid expanding self-closing HTML tags in string form using a regular expression on arbitrary content. Instead, allow the browser's HTML parser to handle these cases, or restrict expansion to strictly controlled contexts. The best fix is to not modify sanitized or untrusted HTML in this way.

**Detailed Fix:**  
Remove or restrict the usage of `elem.replace( rxhtmlTag, "<$1></$2>" )` on line 5605. Instead, always insert the raw HTML string (as done in the `if` branch above), allowing the browser to handle self-closing tags.

**Regions to Update:**  
- In file `nano/js/libraries/jquery.js`, lines 5600–5606: Remove the else-branch doing the expansion, always insert `elem` as HTML directly (`tmp.innerHTML = wrap[1] + elem + wrap[2];`).

**What is Needed:**  
- Only update the conditional to unconditionally use the safe branch.
- No dependencies or extra methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
