### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -113,15 +113,24 @@ function linkify(parent, insertBefore, text) {
 
 		// Final protocol validation: Only allow strictly http/https links
 		var safeHref = href.trim();
-		if (!/^https?:\/\//i.test(safeHref)) {
-			// Unsafe protocol, downgrade to plain text
+		let url;
+		try {
+			url = new URL(safeHref, window.location.origin);
+		} catch (e) {
+			// Invalid URL, insert plain text
+			parent.insertBefore(document.createTextNode(match[0]), insertBefore);
+			start = regex.lastIndex;
+			continue;
+		}
+		if (url.protocol !== "http:" && url.protocol !== "https:") {
+			// Unsafe or disallowed protocol, insert plain text
 			parent.insertBefore(document.createTextNode(match[0]), insertBefore);
 			start = regex.lastIndex;
 			continue;
 		}
 		// add the link
 		var link = document.createElement("a");
-		link.href = safeHref;
+		link.href = url.href;
 		link.textContent = match[0];
 		parent.insertBefore(link, insertBefore);
 

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -111,9 +111,17 @@ function linkify(parent, insertBefore, text) {
 			continue;
 		}
 
+		// Final protocol validation: Only allow strictly http/https links
+		var safeHref = href.trim();
+		if (!/^https?:\/\//i.test(safeHref)) {
+			// Unsafe protocol, downgrade to plain text
+			parent.insertBefore(document.createTextNode(match[0]), insertBefore);
+			start = regex.lastIndex;
+			continue;
+		}
 		// add the link
 		var link = document.createElement("a");
-		link.href = href;
+		link.href = safeHref;
 		link.textContent = match[0];
 		parent.insertBefore(link, insertBefore);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Unionstation-13/Unionstation13/security/code-scanning/4](https://github.com/Unionstation-13/Unionstation13/security/code-scanning/4)

To fix the issue, ensure that only safe, whitelisted protocols (`http`, `https`) are permitted for the anchor's `href` attribute, and that URLs built from tainted DOM text cannot be interpreted as actionable JavaScript or data URIs, even via browser quirks. Additionally, apply defensive coding to encode the constructed URL or match it against a strict validation routine. This can be done by explicitly checking that the assigned `href` starts strictly with `http://` or `https://` after trimming, and escaping dangerous control characters. Edits are required in the `linkify` function, around line 116, to only allow `href` values that are valid, safe HTTP(S) URLs. If the URL fails the check, fallback to inserting plain text rather than a link.

You do not need to modify any other regions, nor do you need to change aspects of functionality outside the security-relevant code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
